### PR TITLE
Added two explicit types to avoid undesired behaviour of Rascal typechecker

### DIFF
--- a/src/main/rascal/lang/php/analysis/cfg/BasicBlocks.rsc
+++ b/src/main/rascal/lang/php/analysis/cfg/BasicBlocks.rsc
@@ -74,9 +74,9 @@ public CFG createBasicBlocks(CFG g) {
 	FlowEdge getBlockEdge(CFGNode n1, CFGNode n2) {
 		n1Exit = last(n1.nodes);
 		n2Entry = head(n2.nodes);
-		edges = { e | e <- g.edges, n1Exit.lab == e.from, n2Entry.lab == e.to };
+		edges = { e | FlowEdge e <- g.edges, n1Exit.lab == e.from, n2Entry.lab == e.to };
 		if (size(edges) > 1) {
-			for (e <- edges)
+			for (FlowEdge e <- edges)
 				println("In <g.item>, found flow edge <e>"); 
 			throw "We should not have multiple edges between the same nodes";
 		}


### PR DESCRIPTION
Two trivial changes (adding an explicit FlowEdge type to both `e`s) to make the Rascal typechecker -- and hopefully us ;-) -- happier:

```
FlowEdge getBlockEdge(CFGNode n1, CFGNode n2) {
		n1Exit = last(n1.nodes);
		n2Entry = head(n2.nodes);
		edges = { e | FlowEdge e <- g.edges, n1Exit.lab == e.from, n2Entry.lab == e.to };
		if (size(edges) > 1) {
			for (FlowEdge e <- edges)
				println("In <g.item>, found flow edge <e>"); 
			throw "We should not have multiple edges between the same nodes";
		}
		e = getOneFrom(edges);
		return e[from=n1.lab][to=n2.lab];
	}
```